### PR TITLE
Features/350 ESLint rules

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,30 +1,30 @@
 {
-    "extends": [
-      "plugin:import/errors",
-      "plugin:import/warnings",
-      "eslint:recommended",
-      "prettier"
-    ],
-    "settings": {
-      "import/resolver": {
-        "babel-module": {}
-      }
-    },
-    "rules": {
-      "brace-style": ["error", "stroustrup"],
-      "capitalized-comments": ["error", "never"],
-      "jsx-quotes": ["error", "prefer-double"],
-      "arrow-spacing": "error",
-      "eqeqeq": ["error", "always"],
-      "no-const-assign": "error",
-      "no-shadow": "error",
-      "no-trailing-spaces": "error",
-      "no-unneeded-ternary": "error",
-      "no-var": "error",
-      "object-curly-spacing": ["error", "always"],
-      "sort-imports": "error",
-      "sort-keys": ["error", "asc"],
-      "space-before-blocks": ["error", "always"],
-      "quotes": ["error", "single", { "allowTemplateLiterals": true }],
+  "extends": [
+    "plugin:import/errors",
+    "plugin:import/warnings",
+    "eslint:recommended",
+    "prettier"
+  ],
+  "settings": {
+    "import/resolver": {
+      "babel-module": {}
     }
+  },
+  "rules": {
+    "brace-style": ["error", "stroustrup"],
+    "capitalized-comments": ["error", "never"],
+    "jsx-quotes": ["error", "prefer-double"],
+    "arrow-spacing": "error",
+    "eqeqeq": ["error", "always"],
+    "no-const-assign": "error",
+    "no-shadow": "error",
+    "no-trailing-spaces": "error",
+    "no-unneeded-ternary": "error",
+    "no-var": "error",
+    "object-curly-spacing": ["error", "always"],
+    "sort-imports": "error",
+    "sort-keys": ["error", "asc"],
+    "space-before-blocks": ["error", "always"],
+    "quotes": ["error", "single", {"allowTemplateLiterals": true}]
+  }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -1,11 +1,30 @@
 {
     "extends": [
       "plugin:import/errors",
-      "plugin:import/warnings"
+      "plugin:import/warnings",
+      "eslint:recommended",
+      "prettier"
     ],
     "settings": {
       "import/resolver": {
         "babel-module": {}
       }
+    },
+    "rules": {
+      "brace-style": ["error", "stroustrup"],
+      "capitalized-comments": ["error", "never"],
+      "jsx-quotes": ["error", "prefer-double"],
+      "arrow-spacing": "error",
+      "eqeqeq": ["error", "always"],
+      "no-const-assign": "error",
+      "no-shadow": "error",
+      "no-trailing-spaces": "error",
+      "no-unneeded-ternary": "error",
+      "no-var": "error",
+      "object-curly-spacing": ["error", "always"],
+      "sort-imports": "error",
+      "sort-keys": ["error", "asc"],
+      "space-before-blocks": ["error", "always"],
+      "quotes": ["error", "single", { "allowTemplateLiterals": true }],
     }
 }

--- a/.eslintrc
+++ b/.eslintrc
@@ -24,6 +24,7 @@
     "object-curly-spacing": ["error", "always"],
     "sort-imports": "error",
     "sort-keys": ["error", "asc"],
+    "sort-vars": "error",
     "space-before-blocks": ["error", "always"],
     "quotes": ["error", "single", {"allowTemplateLiterals": true}]
   }

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -3,5 +3,5 @@ module.exports = {
   jsxBracketSameLine: true,
   singleQuote: true,
   trailingComma: 'all',
-  endOfLine: "auto",
+  endOfLine: 'auto',
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "travellan",
-  "version": "0.0.1",
+  "version": "0.4.0",
   "private": true,
   "scripts": {
     "android": "react-native run-android",


### PR DESCRIPTION
I added several rules to **ESLint** configuration:

```
"extends": [
    ...
    "eslint:recommended",
    "prettier"
]
```

- [brace-style](https://eslint.org/docs/rules/brace-style),
`"brace-style": ["error", "stroustrup"]`
- [capitalized-comments](https://eslint.org/docs/rules/capitalized-comments),
`"capitalized-comments": ["error", "never"]`
- [jsx-quotes](https://eslint.org/docs/rules/jsx-quotes),
`"jsx-quotes": ["error", "prefer-double"]`
- [arrow-spacing](https://eslint.org/docs/rules/arrow-spacing),
`"arrow-spacing": "error"`
- [eqeqeq](https://eslint.org/docs/rules/eqeqeq),
`"eqeqeq": ["error", "always"]`
- [no-const-assign](https://eslint.org/docs/rules/no-const-assign),
`"no-const-assign": "error"`
- [no-shadow](https://eslint.org/docs/rules/no-shadow),
`"no-shadow": "error"`
- [no-trailing-spaces](https://eslint.org/docs/rules/no-trailing-spaces),
`"no-trailing-spaces": "error"`
- [no-unneeded-ternary](https://eslint.org/docs/rules/no-unneeded-ternary),
`"no-unneeded-ternary": "error"`
- [no-var](https://eslint.org/docs/rules/no-var),
`"no-var": "error"`
- [object-curly-spacing](https://eslint.org/docs/rules/object-curly-spacing),
`"object-curly-spacing": ["error", "always"]`
- [sort-imports](https://eslint.org/docs/rules/sort-imports),
`"sort-imports": "error"`
- [sort-keys](https://eslint.org/docs/rules/sort-keys),
`"sort-keys": ["error", "asc"]`
- [sort-vars](https://eslint.org/docs/rules/sort-vars),
`sort-vars: "error"`
- [space-before-blocks](https://eslint.org/docs/rules/space-before-blocks),
`"space-before-blocks": ["error", "always"]`
- [quotes](https://eslint.org/docs/rules/quotes),
`"quotes": ["error", "single", {"allowTemplateLiterals": true}]`