### PR TITLE
Feature/417 autofix sort keys

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -17,10 +17,11 @@ module.exports = {
     'no-var': 'error',
     'object-curly-spacing': ['error', 'always'],
     'sort-imports': 'error',
-    'sort-keys': ['error', 'asc'],
+    'sort-keys': ['error', 'asc', { natural: true }],
     'space-before-blocks': ['error', 'always'],
     quotes: ['error', 'single', { allowTemplateLiterals: true }],
     'prettier/prettier': 'error',
+    'sort-keys-fix/sort-keys-fix': 'error'
   },
-  plugins: ['prettier'],
+  plugins: ['prettier', 'sort-keys-fix'],
 };

--- a/package.json
+++ b/package.json
@@ -90,6 +90,7 @@
     "eslint": "^6.8.0",
     "eslint-plugin-prettier": "^3.3.0",
     "eslint-plugin-sort-imports-es6-autofix": "^0.5.0",
+    "eslint-plugin-sort-keys-fix": "^1.1.1",
     "jest": "^25.5.3",
     "metro-react-native-babel-preset": "^0.59.0",
     "react-devtools": "^4.8.2",

--- a/src/domains/accommodation/containers/AccommodationContainerStyle.js
+++ b/src/domains/accommodation/containers/AccommodationContainerStyle.js
@@ -3,57 +3,57 @@ import { spacingForCardInset } from 'domains/accommodation/components/Accommodat
 import Colors from 'constants/Colors';
 
 export const styles = StyleSheet.create({
+  button: {
+    alignItems: 'center',
+    backgroundColor: Colors.primary,
+    borderRadius: 10,
+    margin: 10,
+    padding: 15,
+    width: '40%',
+  },
+  buttonText: {
+    color: Colors.text,
+    fontSize: 16,
+    fontWeight: 'bold',
+  },
+  centered: {
+    alignContent: 'center',
+    flex: 1,
+    justifyContent: 'center',
+  },
+  columnAndRowCenter: {
+    alignItems: 'center',
+    justifyContent: 'center',
+  },
   contentContainer: {
-    paddingTop: '12%',
+    backgroundColor: Colors.background,
     flex: 1,
     flexGrow: 1,
     justifyContent: 'center',
-    backgroundColor: Colors.background,
     paddingHorizontal: Platform.OS === 'android' ? spacingForCardInset : 0,
+    paddingTop: '12%',
   },
   contentInsetIOS: {
-    top: 0,
-    left: spacingForCardInset,
     bottom: 0,
+    left: spacingForCardInset,
     right: spacingForCardInset,
+    top: 0,
   },
-  columnAndRowCenter: {
-    justifyContent: 'center',
-    alignItems: 'center',
-  },
-  centered: {
-    flex: 1,
-    justifyContent: 'center',
-    alignContent: 'center',
-  },
-  rowDirection: {
-    justifyContent: 'center',
-    flexDirection: 'row',
-  },
-  text: {
-    color: Colors.text,
-  },
-  button: {
-    borderRadius: 10,
+  dot: {
     backgroundColor: Colors.primary,
-    alignItems: 'center',
-    width: '40%',
-    padding: 15,
-    margin: 10,
-  },
-  buttonText: {
-    fontWeight: 'bold',
-    fontSize: 16,
-    color: Colors.text,
+    borderRadius: 5,
+    height: 10,
+    margin: 8,
+    width: 10,
   },
   icon: {
     margin: 10,
   },
-  dot: {
-    height: 10,
-    width: 10,
-    backgroundColor: Colors.primary,
-    margin: 8,
-    borderRadius: 5,
+  rowDirection: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+  },
+  text: {
+    color: Colors.text,
   },
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -3951,6 +3951,13 @@ eslint-plugin-sort-imports-es6-autofix@^0.5.0:
   dependencies:
     eslint "^6.2.2"
 
+eslint-plugin-sort-keys-fix@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/eslint-plugin-sort-keys-fix/-/eslint-plugin-sort-keys-fix-1.1.1.tgz#2ed201b53fd4a89552c6e2abd38933f330a4b62e"
+  integrity sha512-x02SLBg+8OEaoT9vvMbsgeInw17wjHLsa9cOieIVQY+xMNRiXBbyMWw+NiBoxYyJIR4QKDOPDofCjQdoSvltQg==
+  dependencies:
+    requireindex "~1.2.0"
+
 eslint-scope@^5.0.0:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/eslint-scope/-/eslint-scope-5.1.1.tgz#e786e59a66cb92b3f6c1fb0d508aab174848f48c"
@@ -8321,6 +8328,11 @@ require-main-filename@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/require-main-filename/-/require-main-filename-2.0.0.tgz#d0b329ecc7cc0f61649f62215be69af54aa8989b"
   integrity sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+
+requireindex@~1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/requireindex/-/requireindex-1.2.0.tgz#3463cdb22ee151902635aa6c9535d4de9c2ef1ef"
+  integrity sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==
 
 reselect@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
## Changes made

- I added a dependency: [eslint-plugin-sort-keys-fix](https://www.npmjs.com/package/eslint-plugin-sort-keys-fix),
- I configured the plugin,
- I tested the plugin on some styles and it works as expected.

## Screenshots

![sort-keys-autofix](https://user-images.githubusercontent.com/32842468/103770342-25e9f100-5026-11eb-8e71-603c69d40142.gif)

## Test path (if necessary)

Check it out in VSCode! Remember, you should have the Prettier and ESLint configured in the editor.

## Checklist

- [ ] merged develop branch into feature branch
- [ ] tested locally
  - [ ] in emulator
  - [ ] on a real device
- [ ] added new dependencies (what deps?)
- [ ] used ESLint (linted) and Prettier (formatted)
- [ ] updated the docs
- [ ] added a test
